### PR TITLE
Fix the node container volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,4 @@ services:
     build:
       context: docker/node
     volumes:
-      - ./:/var/www/cached
+      - ./:/var/www:cached


### PR DESCRIPTION
Fixes a typo in docker-compose.yml that was preventing proper mounting of the
node container volume.
